### PR TITLE
fix: reduce INP regression and stabilize media imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,16 @@
 
         // Optimize theme transitions
         document.documentElement.style.setProperty('--theme-transition-duration', '300ms');
+
+        const enableThemeTransitions = () => {
+          document.body?.classList.add('theme-transition');
+        };
+
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', () => requestAnimationFrame(enableThemeTransitions), { once: true });
+        } else {
+          requestAnimationFrame(enableThemeTransitions);
+        }
       })();
     </script>
 

--- a/src/components/layout/GlobalHeader.tsx
+++ b/src/components/layout/GlobalHeader.tsx
@@ -115,7 +115,7 @@ export default function GlobalHeader() {
                 ? 'md:flex w-0 opacity-0 scale-x-0' 
                 : 'flex w-auto opacity-100 scale-x-100'
             }`}>
-              <button 
+              <button
                 onClick={handleHome}
                 data-onboarding-target="home-button"
                 className={`w-8 h-8 rounded-full object-cover flex-shrink-0 hover:opacity-80 transition-all duration-300 ease-out ${
@@ -123,10 +123,14 @@ export default function GlobalHeader() {
                 }`}
                 title="Go to dashboard"
               >
-                <img 
-                  src="/favicon.png" 
-                  alt="WIGG Logo" 
+                <img
+                  src="/favicon.png"
+                  alt="WIGG Logo"
                   className="w-full h-full rounded-full object-cover"
+                  width="32"
+                  height="32"
+                  loading="eager"
+                  decoding="async"
                 />
               </button>
               {(title || subtitle) && (

--- a/src/components/media/MediaSearch.tsx
+++ b/src/components/media/MediaSearch.tsx
@@ -227,6 +227,10 @@ export function MediaSearch({ onMediaSelect, className = "" }: MediaSearchProps)
                         src={media.coverImage}
                         alt={media.title}
                         className="w-12 h-16 object-cover rounded"
+                        width="48"
+                        height="64"
+                        loading="lazy"
+                        decoding="async"
                       />
                     )}
                     <div className="flex-1 min-w-0">

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,4 +1,4 @@
-﻿import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Bell, Check, Loader2 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { useNavigate } from 'react-router-dom';
@@ -30,6 +30,15 @@ export function NotificationBell() {
     pushSupported,
   } = useNotifications();
   const [open, setOpen] = useState(false);
+
+  const notificationsForDisplay = useMemo(
+    () =>
+      notifications.map((notification) => ({
+        notification,
+        relativeTime: formatTimestamp(notification.createdAt),
+      })),
+    [notifications]
+  );
 
   const handleNotificationClick = async (notification: typeof notifications[number]) => {
     if (!notification.readAt) {
@@ -87,7 +96,7 @@ export function NotificationBell() {
         ) : (
           <ScrollArea className="max-h-72">
             <ul className="divide-y divide-border">
-              {notifications.map((notification) => (
+              {notificationsForDisplay.map(({ notification, relativeTime }) => (
                 <li key={notification.id}>
                   <button
                     onClick={() => handleNotificationClick(notification)}
@@ -101,7 +110,7 @@ export function NotificationBell() {
                         {notification.title}
                       </p>
                       <span className="whitespace-nowrap text-[11px] text-muted-foreground">
-                        {formatTimestamp(notification.createdAt)}
+                        {relativeTime}
                       </span>
                     </div>
                     {notification.body && (

--- a/src/components/tmdb/TmdbSearch.tsx
+++ b/src/components/tmdb/TmdbSearch.tsx
@@ -37,7 +37,15 @@ export function TmdbSearch({ onSelect, mode = 'movie' }: Props) {
             >
               <div className="w-[46px] h-[69px] flex-shrink-0 rounded overflow-hidden bg-muted">
                 {poster ? (
-                  <img src={poster} alt="poster" className="w-full h-full object-cover" />
+                  <img
+                    src={poster}
+                    alt="poster"
+                    className="w-full h-full object-cover"
+                    width="46"
+                    height="69"
+                    loading="lazy"
+                    decoding="async"
+                  />
                 ) : (
                   <div className="w-full h-full" />
                 )}

--- a/src/index.css
+++ b/src/index.css
@@ -19,14 +19,16 @@ All colors MUST be HSL.
     --theme-transition-easing: cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  /* GPU-accelerated theme transitions */
-  * {
-    transition: background-color var(--theme-transition-duration) var(--theme-transition-easing),
-                border-color var(--theme-transition-duration) var(--theme-transition-easing),
-                color var(--theme-transition-duration) var(--theme-transition-easing),
-                fill var(--theme-transition-duration) var(--theme-transition-easing),
-                stroke var(--theme-transition-duration) var(--theme-transition-easing),
-                box-shadow var(--theme-transition-duration) var(--theme-transition-easing);
+  /* Opt-in theme transitions to avoid recalculating styles for every element */
+  @media (prefers-reduced-motion: no-preference) {
+    .theme-transition * {
+      transition: background-color var(--theme-transition-duration) var(--theme-transition-easing),
+                  border-color var(--theme-transition-duration) var(--theme-transition-easing),
+                  color var(--theme-transition-duration) var(--theme-transition-easing),
+                  fill var(--theme-transition-duration) var(--theme-transition-easing),
+                  stroke var(--theme-transition-duration) var(--theme-transition-easing),
+                  box-shadow var(--theme-transition-duration) var(--theme-transition-easing);
+    }
   }
 
   /* Font optimization for reduced layout shift */

--- a/src/pages/MediaDetails.tsx
+++ b/src/pages/MediaDetails.tsx
@@ -288,7 +288,7 @@ export default function MediaDetails() {
           // Display image backdrop when available
           <>
             {isGame ? (
-              <picture 
+              <picture
                 className="cursor-pointer"
                 onClick={() => setEnlargedImage({ url: resizeIgdbImage(backdropUrl, 't_original') || backdropUrl, alt: title })}
               >
@@ -298,15 +298,19 @@ export default function MediaDetails() {
                   src={resizeIgdbImage(backdropUrl, 't_original') || backdropUrl}
                   alt={title}
                   className="w-full h-full object-cover"
+                  width="1280"
+                  height="720"
                   decoding="async"
                   onError={() => setBgError(true)}
                 />
               </picture>
             ) : (
-              <img 
-                src={backdropUrl} 
-                alt={title} 
-                className="w-full h-full object-cover cursor-pointer" 
+              <img
+                src={backdropUrl}
+                alt={title}
+                className="w-full h-full object-cover cursor-pointer"
+                width="1280"
+                height="720"
                 onError={() => setBgError(true)}
                 onClick={() => setEnlargedImage({ url: backdropUrl, alt: title })}
               />
@@ -339,6 +343,10 @@ export default function MediaDetails() {
                       src={posterUrl}
                       alt={title}
                       className="w-full aspect-[2/3] object-cover cursor-pointer"
+                      width="400"
+                      height="600"
+                      loading="lazy"
+                      decoding="async"
                       onClick={() => setEnlargedImage({ url: posterUrl, alt: title })}
                     />
                   ) : (
@@ -488,6 +496,10 @@ export default function MediaDetails() {
                   src={posterUrl}
                   alt={title}
                   className="w-full aspect-[2/3] object-cover cursor-pointer"
+                  width="400"
+                  height="600"
+                  loading="lazy"
+                  decoding="async"
                   onClick={() => setEnlargedImage({ url: posterUrl, alt: title })}
                 />
               ) : (
@@ -508,6 +520,8 @@ export default function MediaDetails() {
               src={enlargedImage.url}
               alt={enlargedImage.alt}
               className="max-w-full max-h-[95vh] object-contain"
+              loading="lazy"
+              decoding="async"
             />
           )}
         </DialogContent>


### PR DESCRIPTION
## Summary
- memoize notification timestamp formatting to remove repeated expensive date-fns work during menu interactions
- scope theme transitions behind an opt-in class and delay activation to avoid global restyles on every paint
- add intrinsic sizing and lazy-loading hints to media imagery (header logo, search results, TMDB tiles, media details) to prevent layout shifts

## Testing
- npm run lint *(fails: repo-wide lint issues in apps and storybook packages unrelated to this change)*
- npm test *(fails: numerous suites require missing Supabase/TMDB env vars and other repository-wide setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d59c902c4c8331b43da9381ce8f906