### PR TITLE
feat: improve core accessibility flows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,22 +29,30 @@ const App = () => (
         <OnboardingProvider>
           <NotificationProvider>
             <div className="min-h-screen bg-background">
+              <a
+                href="#main-content"
+                className="skip-link"
+              >
+                Skip to main content
+              </a>
               <GlobalHeader />
-              <Routes>
-                <Route path="/" element={<Index />} />
-                <Route path="/dashboard" element={<Dashboard />} />
-                <Route path="/auth" element={<Auth />} />
-                <Route path="/wigg-demo" element={<WiggDemo />} />
-                <Route path="/add-wigg" element={<AddWigg />} />
-                <Route path="/add-wigg/:mode" element={<AddWigg />} />
-                <Route path="/tmdb" element={<TmdbDemo />} />
-                <Route path="/search" element={<SearchPage />} />
-                <Route path="/feed" element={<Feed />} />
-                <Route path="/test-nav" element={<TestNavigation />} />
-                <Route path="/media/:source/:id" element={<MediaDetails />} />
-                <Route path="/profile" element={<Profile />} />
-                <Route path="*" element={<NotFound />} />
-              </Routes>
+              <main id="main-content" tabIndex={-1} className="focus:outline-none">
+                <Routes>
+                  <Route path="/" element={<Index />} />
+                  <Route path="/dashboard" element={<Dashboard />} />
+                  <Route path="/auth" element={<Auth />} />
+                  <Route path="/wigg-demo" element={<WiggDemo />} />
+                  <Route path="/add-wigg" element={<AddWigg />} />
+                  <Route path="/add-wigg/:mode" element={<AddWigg />} />
+                  <Route path="/tmdb" element={<TmdbDemo />} />
+                  <Route path="/search" element={<SearchPage />} />
+                  <Route path="/feed" element={<Feed />} />
+                  <Route path="/test-nav" element={<TestNavigation />} />
+                  <Route path="/media/:source/:id" element={<MediaDetails />} />
+                  <Route path="/profile" element={<Profile />} />
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
+              </main>
               <OnboardingFlow />
               <Analytics />
               <SpeedInsights />

--- a/src/components/layout/GlobalHeader.tsx
+++ b/src/components/layout/GlobalHeader.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, User } from 'lucide-react';
@@ -15,20 +15,21 @@ export default function GlobalHeader() {
   const { user } = useAuth();
   const [isMobileSearchExpanded, setIsMobileSearchExpanded] = useState(false);
   const headerRef = useRef<HTMLElement>(null);
-  
-  const { 
-    title, 
-    subtitle, 
-    showBackButton = true, 
-    showHomeButton = true, 
-    rightContent 
+  const searchInputId = useId();
+
+  const {
+    title,
+    subtitle,
+    showBackButton = true,
+    showHomeButton = true,
+    rightContent
   } = config;
-  
+
   // Determine if we should show navigation buttons based on current route
   const isHomePage = location.pathname === '/';
   const isDashboardPage = location.pathname === '/dashboard';
-  const canGoBack = window.history.length > 1;
-  
+  const canGoBack = typeof window !== 'undefined' && window.history.length > 1;
+
   const handleBack = () => {
     if (canGoBack) {
       navigate(-1);
@@ -36,7 +37,7 @@ export default function GlobalHeader() {
       navigate('/');
     }
   };
-  
+
   const handleHome = () => {
     navigate('/dashboard');
   };
@@ -80,20 +81,23 @@ export default function GlobalHeader() {
       clearTimeout(timeoutId);
     };
   }, [isMobileSearchExpanded]);
-  
+
   // Don't show header on home page to preserve the hero design
   if (isHomePage) {
     return null;
   }
-  
+
   return (
-    <header ref={headerRef} className="border-b border-border/50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 left-0 right-0 z-[100] relative">
+    <header
+      ref={headerRef}
+      className="border-b border-border/50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 left-0 right-0 z-[100] relative"
+    >
       <div className="container mx-auto px-4 py-2.5">
         <div className="flex items-center justify-between">
           {/* Left: Navigation and Title */}
           <div className="flex items-center gap-4 flex-1">
             {/* Navigation Buttons */}
-            <div className="flex items-center gap-2">
+            <nav className="flex items-center gap-2" aria-label="Primary">
               {showBackButton && !isHomePage && !isDashboardPage && (
                 <Button
                   variant="outline"
@@ -102,37 +106,44 @@ export default function GlobalHeader() {
                   className="flex items-center gap-2"
                   title="Go back"
                 >
-                  <ArrowLeft className="h-4 w-4" />
+                  <ArrowLeft className="h-4 w-4" aria-hidden />
                   <span className="hidden sm:inline">Back</span>
                 </Button>
               )}
-              
-            </div>
-            
+            </nav>
+
             {/* Page Title with smooth compression animation */}
-            <div className={`flex items-center gap-3 min-w-0 transition-all duration-300 ease-out overflow-hidden ${
-              isMobileSearchExpanded 
-                ? 'md:flex w-0 opacity-0 scale-x-0' 
-                : 'flex w-auto opacity-100 scale-x-100'
-            }`}>
-              <button 
-                onClick={handleHome}
-                data-onboarding-target="home-button"
-                className={`w-8 h-8 rounded-full object-cover flex-shrink-0 hover:opacity-80 transition-all duration-300 ease-out ${
-                  isMobileSearchExpanded ? 'scale-75 opacity-0' : 'scale-100 opacity-100'
-                }`}
-                title="Go to dashboard"
-              >
-                <img 
-                  src="/favicon.png" 
-                  alt="WIGG Logo" 
-                  className="w-full h-full rounded-full object-cover"
-                />
-              </button>
+            <div
+              className={`flex items-center gap-3 min-w-0 transition-all duration-300 ease-out overflow-hidden ${
+                isMobileSearchExpanded
+                  ? 'md:flex w-0 opacity-0 scale-x-0'
+                  : 'flex w-auto opacity-100 scale-x-100'
+              }`}
+            >
+              {showHomeButton && (
+                <button
+                  onClick={handleHome}
+                  data-onboarding-target="home-button"
+                  className={`w-8 h-8 rounded-full object-cover flex-shrink-0 hover:opacity-80 transition-all duration-300 ease-out ${
+                    isMobileSearchExpanded ? 'scale-75 opacity-0' : 'scale-100 opacity-100'
+                  }`}
+                  type="button"
+                  aria-label="Go to dashboard"
+                  title="Go to dashboard"
+                >
+                  <img
+                    src="/favicon.png"
+                    alt="WIGG Logo"
+                    className="w-full h-full rounded-full object-cover"
+                  />
+                </button>
+              )}
               {(title || subtitle) && (
-                <div className={`min-w-0 transition-all duration-300 ease-out ${
-                  isMobileSearchExpanded ? 'w-0 opacity-0 scale-x-0' : 'w-auto opacity-100 scale-x-100'
-                }`}>
+                <div
+                  className={`min-w-0 transition-all duration-300 ease-out ${
+                    isMobileSearchExpanded ? 'w-0 opacity-0 scale-x-0' : 'w-auto opacity-100 scale-x-100'
+                  }`}
+                >
                   {title && (
                     <h1 className="text-lg sm:text-xl font-bold bg-gradient-primary bg-clip-text text-transparent truncate whitespace-nowrap">
                       {title}
@@ -146,32 +157,36 @@ export default function GlobalHeader() {
                 </div>
               )}
             </div>
-            
+
             {/* Mobile search with smooth expansion animation */}
-            <div className={`md:hidden transition-all duration-300 ease-out overflow-hidden ${
-              isMobileSearchExpanded 
-                ? 'flex-1 opacity-100 scale-x-100' 
-                : 'w-0 opacity-0 scale-x-0'
-            }`}>
+            <div
+              className={`md:hidden transition-all duration-300 ease-out overflow-hidden ${
+                isMobileSearchExpanded
+                  ? 'flex-1 opacity-100 scale-x-100'
+                  : 'w-0 opacity-0 scale-x-0'
+              }`}
+            >
               {isMobileSearchExpanded && (
-                <HeaderSearch 
-                  isExpanded={isMobileSearchExpanded} 
+                <HeaderSearch
+                  isExpanded={isMobileSearchExpanded}
                   onToggle={setIsMobileSearchExpanded}
+                  inputId={searchInputId}
                 />
               )}
             </div>
           </div>
-          
+
           {/* Right: Search, Custom Content, and Theme Toggle */}
           <div className="flex items-center gap-3">
             {!isMobileSearchExpanded && (
-              <HeaderSearch 
-                isExpanded={isMobileSearchExpanded} 
+              <HeaderSearch
+                isExpanded={isMobileSearchExpanded}
                 onToggle={setIsMobileSearchExpanded}
+                inputId={searchInputId}
               />
             )}
             {rightContent}
-            
+
             {user && <NotificationBell />}
             {/* Profile button - only show when logged in */}
             {user && (
@@ -181,11 +196,11 @@ export default function GlobalHeader() {
                 onClick={() => navigate('/profile')}
                 className="flex items-center gap-1"
               >
-                <User className="h-4 w-4" />
+                <User className="h-4 w-4" aria-hidden />
                 <span className="hidden sm:inline">Profile</span>
               </Button>
             )}
-            
+
             <div className="hidden sm:block">
               <ThemeToggle />
             </div>
@@ -195,4 +210,3 @@ export default function GlobalHeader() {
     </header>
   );
 }
-

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -1,4 +1,4 @@
-﻿import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Button } from '@/components/ui/button';
 import { useOnboarding } from '@/contexts/OnboardingContext';
@@ -70,7 +70,7 @@ const STEPS: OnboardingStep[] = [
 ];
 
 export function OnboardingFlow() {
-  const { isActive, step, setStep, skip, complete} = useOnboarding();
+  const { isActive, step, setStep, skip, complete } = useOnboarding();
 
   const clampedIndex = useMemo(() => {
     if (Number.isNaN(step)) return 0;
@@ -78,6 +78,8 @@ export function OnboardingFlow() {
   }, [step]);
 
   const activeStep = STEPS[clampedIndex];
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null);
 
   const handleNext = useCallback(() => {
     if (clampedIndex >= STEPS.length - 1 || activeStep?.final) {
@@ -99,6 +101,9 @@ export function OnboardingFlow() {
     if (!isActive) return;
     if (typeof window === 'undefined') return;
     const keyHandler = (event: KeyboardEvent) => {
+      if (!dialogRef.current) {
+        return;
+      }
       if (event.key === 'Escape') {
         skip();
       }
@@ -107,6 +112,25 @@ export function OnboardingFlow() {
       }
       if (event.key === 'ArrowLeft') {
         handleBack();
+      }
+      if (event.key === 'Tab') {
+        const focusableElements = dialogRef.current.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusableElements.length === 0) {
+          return;
+        }
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+        if (event.shiftKey) {
+          if (document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
       }
     };
     window.addEventListener('keydown', keyHandler);
@@ -136,6 +160,24 @@ export function OnboardingFlow() {
     };
   }, [isActive]);
 
+  useEffect(() => {
+    if (typeof document === 'undefined' || typeof window === 'undefined') return;
+    if (!isActive) {
+      if (previouslyFocusedElement.current && previouslyFocusedElement.current.isConnected) {
+        previouslyFocusedElement.current.focus();
+      }
+      previouslyFocusedElement.current = null;
+      return;
+    }
+    previouslyFocusedElement.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const frame = window.requestAnimationFrame(() => {
+      dialogRef.current?.focus();
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [isActive]);
+
   if (!isActive || !activeStep) {
     return null;
   }
@@ -143,15 +185,28 @@ export function OnboardingFlow() {
   const progressPercent = ((clampedIndex + 1) / STEPS.length) * 100;
   const Icon = activeStep.icon;
   const headingId = `onboarding-step-${activeStep.id}`;
+  const descriptionId = `${headingId}-description`;
+  const liveRegionId = `${headingId}-live`;
 
   const overlay = (
     <div className="fixed inset-0 z-[220] pointer-events-none">
-      <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" />
+      <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" aria-hidden="true" />
       <div className="absolute inset-0 flex items-end md:items-center justify-center md:justify-end lg:justify-center p-4 md:p-8 pointer-events-none">
-        <div className="pointer-events-auto w-full max-w-lg rounded-3xl border border-border/60 bg-card/95 shadow-2xl shadow-primary/10 backdrop-blur px-6 py-6 md:px-8 md:py-7 space-y-6 animate-in fade-in slide-in-from-bottom-6 md:slide-in-from-right-6" role="dialog" aria-modal="true" aria-labelledby={headingId}>
+        <div
+          ref={dialogRef}
+          className="pointer-events-auto w-full max-w-lg rounded-3xl border border-border/60 bg-card/95 shadow-2xl shadow-primary/10 backdrop-blur px-6 py-6 md:px-8 md:py-7 space-y-6 animate-in fade-in slide-in-from-bottom-6 md:slide-in-from-right-6"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={headingId}
+          aria-describedby={`${descriptionId} ${liveRegionId}`.trim()}
+          tabIndex={-1}
+        >
+          <p id={liveRegionId} className="sr-only" aria-live="polite">
+            Step {clampedIndex + 1} of {STEPS.length}: {activeStep.title}
+          </p>
           <div className="flex items-center gap-3">
             <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-              <Icon className="h-6 w-6" />
+              <Icon className="h-6 w-6" aria-hidden />
             </span>
             <div>
               <p className="text-xs uppercase tracking-wide text-muted-foreground">Step {clampedIndex + 1} of {STEPS.length}</p>
@@ -159,7 +214,7 @@ export function OnboardingFlow() {
             </div>
           </div>
 
-          <p className="text-sm md:text-base text-muted-foreground leading-relaxed">
+          <p id={descriptionId} className="text-sm md:text-base text-muted-foreground leading-relaxed">
             {activeStep.description}
           </p>
 
@@ -175,17 +230,22 @@ export function OnboardingFlow() {
           )}
 
           <div className="space-y-3">
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted" aria-hidden="true">
               <div
                 className="h-full bg-primary transition-all duration-500"
                 style={{ width: `${progressPercent}%` }}
+                role="progressbar"
+                aria-valuemin={1}
+                aria-valuemax={STEPS.length}
+                aria-valuenow={clampedIndex + 1}
+                aria-valuetext={`Step ${clampedIndex + 1} of ${STEPS.length}`}
               />
             </div>
             <div className="flex items-center justify-between gap-3">
               <Button variant="ghost" size="sm" onClick={skip} className="text-muted-foreground" data-testid="onboarding-skip">
                 Skip tour
               </Button>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2" aria-hidden="true">
                 {STEPS.map((stepDef, idx) => (
                   <span
                     key={stepDef.id}
@@ -214,6 +274,3 @@ export function OnboardingFlow() {
 }
 
 export default OnboardingFlow;
-
-
-

--- a/src/components/search/HeaderSearch.tsx
+++ b/src/components/search/HeaderSearch.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Search, X } from 'lucide-react';
@@ -7,11 +7,17 @@ import { useNavigate } from 'react-router-dom';
 interface HeaderSearchProps {
   isExpanded?: boolean;
   onToggle?: (expanded: boolean) => void;
+  inputId?: string;
 }
 
-export default function HeaderSearch({ isExpanded = false, onToggle }: HeaderSearchProps) {
+export default function HeaderSearch({ isExpanded = false, onToggle, inputId }: HeaderSearchProps) {
   const [q, setQ] = useState('');
   const navigate = useNavigate();
+  const generatedId = useId();
+  const baseId = inputId ?? generatedId;
+  const desktopInputId = `${baseId}-desktop`;
+  const mobileInputId = `${baseId}-mobile`;
+  const mobileFormId = `${baseId}-mobile-form`;
 
   function go(e?: React.FormEvent) {
     if (e) e.preventDefault();
@@ -31,14 +37,27 @@ export default function HeaderSearch({ isExpanded = false, onToggle }: HeaderSea
   return (
     <>
       {/* Desktop search - always visible */}
-      <form onSubmit={go} className="hidden md:block">
+      <form
+        onSubmit={go}
+        className="hidden md:block"
+        role="search"
+        aria-label="Site search"
+      >
+        <label htmlFor={desktopInputId} className="sr-only">
+          Search the WIGG catalog
+        </label>
         <Input
+          id={desktopInputId}
           value={q}
           onChange={(e) => setQ(e.target.value)}
           placeholder="Search movies, TV, books…"
           data-onboarding-target="search-input"
+          aria-describedby={`${desktopInputId}-description`}
           className="w-80"
         />
+        <p id={`${desktopInputId}-description`} className="sr-only">
+          Type a title or keyword and press Enter to view search results.
+        </p>
       </form>
 
       {/* Mobile search */}
@@ -49,13 +68,26 @@ export default function HeaderSearch({ isExpanded = false, onToggle }: HeaderSea
             size="sm"
             onClick={handleMobileToggle}
             className="flex items-center gap-1 transition-all duration-300 ease-out"
+            aria-label="Open site search"
+            aria-expanded={isExpanded}
+            aria-controls={mobileFormId}
           >
-            <Search className="h-4 w-4 transition-transform duration-300 ease-out hover:scale-110" />
+            <Search className="h-4 w-4 transition-transform duration-300 ease-out hover:scale-110" aria-hidden />
           </Button>
         ) : (
           <div className="flex items-center gap-2 w-full animate-in slide-in-from-right-2 duration-300">
-            <form onSubmit={go} className="flex items-center gap-2 flex-1">
+            <form
+              id={mobileFormId}
+              onSubmit={go}
+              className="flex items-center gap-2 flex-1"
+              role="search"
+              aria-label="Site search"
+            >
+              <label htmlFor={mobileInputId} className="sr-only">
+                Search the WIGG catalog
+              </label>
               <Input
+                id={mobileInputId}
                 value={q}
                 onChange={(e) => setQ(e.target.value)}
                 placeholder="Search…"
@@ -69,8 +101,9 @@ export default function HeaderSearch({ isExpanded = false, onToggle }: HeaderSea
                 type="button"
                 onClick={handleMobileToggle}
                 className="transition-all duration-200 ease-out hover:scale-110 hover:rotate-90"
+                aria-label="Close site search"
               >
-                <X className="h-4 w-4" />
+                <X className="h-4 w-4" aria-hidden />
               </Button>
             </form>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -130,6 +130,25 @@ All colors MUST be HSL.
     contain: layout style;
   }
 
+  .skip-link {
+    position: absolute;
+    left: 1rem;
+    top: 0.75rem;
+    transform: translateY(-150%);
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    padding: 0.5rem 1rem;
+    border-radius: 9999px;
+    font-weight: 600;
+    z-index: 999;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .skip-link:focus {
+    transform: translateY(0);
+    box-shadow: 0 0 0 3px hsl(var(--background)), 0 0 0 6px hsl(var(--primary));
+  }
+
   /* Prevent unnecessary repaints during theme transitions */
   .theme-container {
     contain: layout style paint;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,15 +12,15 @@ const Index = () => {
   return (
     <div className="min-h-screen bg-background">
       {/* Hero Section */}
-      <div className="bg-gradient-hero relative overflow-hidden hero-section">
-        <div className="absolute inset-0 bg-black/10"></div>
+      <section className="bg-gradient-hero relative overflow-hidden hero-section" aria-labelledby="hero-heading">
+        <div className="absolute inset-0 bg-black/10" aria-hidden="true"></div>
         <div className="relative container mx-auto px-4 py-16 md:py-24">
           <div className="absolute right-4 top-4 z-10 flex items-center gap-3">
             <HeaderSearch />
             <ThemeToggle />
           </div>
           <div className="text-center max-w-3xl mx-auto">
-            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6 leading-tight">
+            <h1 id="hero-heading" className="text-4xl md:text-6xl font-bold text-white mb-6 leading-tight">
               When does it get good?
             </h1>
             <p className="text-xl md:text-2xl text-white/90 mb-8 leading-relaxed">
@@ -37,65 +37,68 @@ const Index = () => {
                 <ArrowRight className="ml-2 h-5 w-5" />
               </Button>
               {user ? (
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="lg"
                   className="text-lg px-8 py-4 h-auto bg-white/10 text-white border-white/20 hover:bg-white/20"
                   onClick={signOut}
                 >
-                  <User className="mr-2 h-5 w-5" />
+                  <User className="mr-2 h-5 w-5" aria-hidden />
                   Sign Out
                 </Button>
               ) : (
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="lg"
                   className="text-lg px-8 py-4 h-auto bg-white/10 text-white border-white/20 hover:bg-white/20"
                   onClick={() => navigate("/auth")}
                 >
-                  <User className="mr-2 h-5 w-5" />
+                  <User className="mr-2 h-5 w-5" aria-hidden />
                   Sign In
                 </Button>
               )}
             </div>
           </div>
         </div>
-      </div>
+      </section>
 
       {/* Stats Section */}
-      <div className="py-16 border-b border-border/50">
+      <section className="py-16 border-b border-border/50" aria-labelledby="stats-heading">
         <div className="container mx-auto px-4">
+          <h2 id="stats-heading" className="sr-only">
+            Why WIGG helps you choose what to watch
+          </h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
             <div className="text-center">
               <div className="bg-gradient-primary bg-clip-text text-transparent">
-                <Clock className="h-12 w-12 mx-auto mb-4 text-primary" />
+                <Clock className="h-12 w-12 mx-auto mb-4 text-primary" aria-hidden />
               </div>
               <h3 className="font-semibold text-xl mb-2">Save Time</h3>
               <p className="text-muted-foreground">Know before you commit hours to new media</p>
             </div>
             <div className="text-center">
               <div className="bg-gradient-primary bg-clip-text text-transparent">
-                <TrendingUp className="h-12 w-12 mx-auto mb-4 text-primary" />
+                <TrendingUp className="h-12 w-12 mx-auto mb-4 text-primary" aria-hidden />
               </div>
               <h3 className="font-semibold text-xl mb-2">Find Quality</h3>
               <p className="text-muted-foreground">Discover which shows are worth the investment</p>
             </div>
             <div className="text-center">
               <div className="bg-gradient-primary bg-clip-text text-transparent">
-                <Users className="h-12 w-12 mx-auto mb-4 text-primary" />
+                <Users className="h-12 w-12 mx-auto mb-4 text-primary" aria-hidden />
               </div>
               <h3 className="font-semibold text-xl mb-2">Share Insights</h3>
               <p className="text-muted-foreground">Help others with your viewing experience</p>
             </div>
           </div>
         </div>
-      </div>
+      </section>
 
       {/* Features Section */}
-      <div className="py-16">
+      <section className="py-16" aria-labelledby="features-heading">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
-            <h2 className="text-3xl md:text-4xl font-bold mb-6">
+            <h2 id="features-heading" className="text-3xl md:text-4xl font-bold mb-6">
               How It Works
             </h2>
             <p className="text-xl text-muted-foreground mb-12">
@@ -145,12 +148,12 @@ const Index = () => {
             </div>
           </div>
         </div>
-      </div>
+      </section>
 
       {/* CTA Section */}
-      <div className="py-16 bg-gradient-subtle">
+      <section className="py-16 bg-gradient-subtle" aria-labelledby="cta-heading">
         <div className="container mx-auto px-4 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold mb-4">
+          <h2 id="cta-heading" className="text-3xl md:text-4xl font-bold mb-4">
             Ready to discover when it gets good?
           </h2>
           <p className="text-xl text-muted-foreground mb-8">
@@ -165,7 +168,7 @@ const Index = () => {
             Get Started Now
           </Button>
         </div>
-      </div>
+      </section>
 
       {/* Footer */}
       <footer className="border-t border-border/50 py-8">


### PR DESCRIPTION
## Summary
- add a global skip link and main landmark so keyboard users can bypass repeated navigation
- give the global header/search controls semantic structure and accessible labelling across screen sizes
- harden the onboarding dialog and marketing home page with focus management, landmark sections, and assistive-technology friendly markup

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated Storybook, native, and build artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a0fd57148331b32c25095c030a9c