### PR TITLE
fix: ensure media tile quick wigg modal opens

### DIFF
--- a/src/components/media/MediaTile.tsx
+++ b/src/components/media/MediaTile.tsx
@@ -100,6 +100,7 @@ export function MediaTile({ title, imageUrl, year, ratingLabel, tags, onAdd, onC
     >
       {/* Add WIGG Button */}
       <Button
+        type="button"
         onClick={handleAddWigg}
         onPointerDownCapture={(e) => {
           e.stopPropagation();

--- a/src/components/media/__tests__/MediaTile.auth.test.tsx
+++ b/src/components/media/__tests__/MediaTile.auth.test.tsx
@@ -144,4 +144,50 @@ describe('MediaTile Authentication', () => {
       state: { media: expect.any(Object) },
     });
   });
+
+  it('should open quick wigg modal without submitting surrounding forms', async () => {
+    const { useAuth } = await import('@/hooks/useAuth');
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 'user123', email: 'test@example.com' } as any,
+      session: { user: { id: 'user123' } } as any,
+      loading: false,
+      signIn: vi.fn(),
+      signUp: vi.fn(),
+      signOut: vi.fn(),
+      cleanupAuthState: vi.fn(),
+    });
+
+    const handleSubmit = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <MediaTile
+            title="Test Movie"
+            imageUrl="https://example.com/poster.jpg"
+            year={2023}
+            mediaData={{
+              source: 'tmdb-movie',
+              id: '123',
+              title: 'Test Movie',
+              type: 'movie',
+              posterUrl: 'https://example.com/poster.jpg',
+              year: 2023,
+            }}
+          />
+        </form>
+      </MemoryRouter>
+    );
+
+    const addButton = screen.getByLabelText('Add WIGG point');
+    fireEvent.click(addButton);
+
+    await screen.findByText('Quick Wigg — Test Movie');
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- set the media tile add button type to button so clicking it no longer triggers parent form submission
- add a regression test to verify the quick wigg modal opens without submitting surrounding forms

## Testing
- npm test -- src/components/media/__tests__/MediaTile.auth.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d9918885f4833194baf2f4a82a5fb2